### PR TITLE
Fix trailing line for package.el compatibility

### DIFF
--- a/babel.el
+++ b/babel.el
@@ -894,4 +894,4 @@ If optional argument HERE is non-nil, insert version number at point."
 
 (provide 'babel)
 
-;; babel.el ends here
+;;; babel.el ends here


### PR DESCRIPTION
`package-buffer-info` requires triple-semicolon comments for metadata lines.

Background: we're adding babel to MELPA: https://github.com/milkypostman/melpa/pull/1282
