### PR TITLE
Support google translate v2 api

### DIFF
--- a/babel.el
+++ b/babel.el
@@ -846,6 +846,8 @@ If optional argument HERE is non-nil, insert version number at point."
 	    :test '(lambda (st el)
 		     (string= (cdr el) st))))
       (error "Google can't translate from %s to %s" from to)
+    (if (not babel-google-translate-api-key)
+        (error "Missing api key")
     (let* ((pairs `(("q" . ,(mm-encode-coding-string msg 'utf-8))
                     ("key" . ,babel-google-translate-api-key)
 		    ;; ("source" . ,from)
@@ -856,7 +858,7 @@ If optional argument HERE is non-nil, insert version number at point."
 	    '(("Content-Type" . "application/x-www-form-urlencoded")))
            (url-base "https://translation.googleapis.com")
            (url-path "/language/translate/v2"))
-      (babel-url-retrieve  (concat url-base url-path)))))
+        (babel-url-retrieve  (concat url-base url-path))))))
 
 (defun assoc-> (alist path)
   (let ((prop (car path)))

--- a/babel.el
+++ b/babel.el
@@ -848,16 +848,16 @@ If optional argument HERE is non-nil, insert version number at point."
       (error "Google can't translate from %s to %s" from to)
     (if (not babel-google-translate-api-key)
         (error "Missing api key")
-    (let* ((pairs `(("q" . ,(mm-encode-coding-string msg 'utf-8))
-                    ("key" . ,babel-google-translate-api-key)
-		    ;; ("source" . ,from)
-		    ("target" . ,to)))
-	   (url-request-data (babel-form-encode pairs))
-	   (url-request-method "POST")
-	   (url-request-extra-headers
-	    '(("Content-Type" . "application/x-www-form-urlencoded")))
-           (url-base "https://translation.googleapis.com")
-           (url-path "/language/translate/v2"))
+      (let* ((pairs `(("q" . ,(mm-encode-coding-string msg 'utf-8))
+                      ("key" . ,babel-google-translate-api-key)
+                      ;; ("source" . ,from)
+                      ("target" . ,to)))
+             (url-request-data (babel-form-encode pairs))
+             (url-request-method "POST")
+             (url-request-extra-headers
+              '(("Content-Type" . "application/x-www-form-urlencoded")))
+             (url-base "https://translation.googleapis.com")
+             (url-path "/language/translate/v2"))
         (babel-url-retrieve  (concat url-base url-path))))))
 
 (defun assoc-> (alist path)
@@ -869,7 +869,6 @@ If optional argument HERE is non-nil, insert version number at point."
                        (t (error "type not suppored: %s" prop)))
                  (cdr path))
       alist)))
-
 
 (defun babel-google-wash ()
   "Extract the useful information from the HTML returned by google."

--- a/babel.el
+++ b/babel.el
@@ -411,6 +411,16 @@ translated text should be inside parenthesized expression in regex"
 	(delete-region (point-min) (match-beginning 1))
 	t)))
 
+(defun babel-string (msg from to service)
+  (let* ((backend (symbol-name service))
+         (fetcher (intern (concat "babel-" backend "-fetch")))
+         (washer  (intern (concat "babel-" backend "-wash")))
+         (msg-max 7000))
+    (loop for chunk in (babel-chunkify msg msg-max)
+	  collect (babel-work chunk from to fetcher washer)
+          into translated-chunks
+          finally (return (apply #'concat (nreverse translated-chunks))))))
+
 ;;;###autoload
 (defun babel (msg &optional no-display accept-default-setup)
   "Use a web translation service to translate the message MSG.

--- a/babel.el
+++ b/babel.el
@@ -338,6 +338,11 @@ configuration."
    :type 'boolean
    :group 'babel)
 
+(defcustom babel-google-translate-api-key
+  nil
+  "Google translate api key."
+  :type 'string
+  :group 'babel)
 
 (defvar babel-previous-window-configuration nil
   "The window configuration before transform.")
@@ -362,7 +367,7 @@ configuration."
   "Keymap used in Babel mode.")
 
 (defvar babel-backends
-  '(;;  ("Google" . google), disabled because of non-possible limited API-KEY based usage
+  '(("Google" . google)
     ("FreeTranslation" . free)
     ("Apertium" .  apertium))
   "List of backends for babel translations.")
@@ -831,15 +836,28 @@ If optional argument HERE is non-nil, insert version number at point."
 	    :test '(lambda (st el)
 		     (string= (cdr el) st))))
       (error "Google can't translate from %s to %s" from to)
-    (let* ((langpair (format "%s|%s" from to))
-	   (pairs `(("q"       . ,(mm-encode-coding-string msg 'utf-8))
-		    ("langpair" . ,langpair)
-		    ("v" . "1.0")))
+    (let* ((pairs `(("q" . ,(mm-encode-coding-string msg 'utf-8))
+                    ("key" . ,babel-google-translate-api-key)
+		    ;; ("source" . ,from)
+		    ("target" . ,to)))
 	   (url-request-data (babel-form-encode pairs))
 	   (url-request-method "POST")
 	   (url-request-extra-headers
-	    '(("Content-Type" . "application/x-www-form-urlencoded"))))
-      (babel-url-retrieve  "http://ajax.googleapis.com/ajax/services/language/translate"))))
+	    '(("Content-Type" . "application/x-www-form-urlencoded")))
+           (url-base "https://translation.googleapis.com")
+           (url-path "/language/translate/v2"))
+      (babel-url-retrieve  (concat url-base url-path)))))
+
+(defun assoc-> (alist path)
+  (let ((prop (car path)))
+    (if prop
+        (assoc-> (cond ((symbolp prop) (cdr (assoc (car path) alist)))
+                       ((numberp prop)
+                        (aref alist prop))
+                       (t (error "type not suppored: %s" prop)))
+                 (cdr path))
+      alist)))
+
 
 (defun babel-google-wash ()
   "Extract the useful information from the HTML returned by google."
@@ -847,10 +865,13 @@ If optional argument HERE is non-nil, insert version number at point."
   (let* ((json-object-type 'alist)
 	 (json-response (json-read)))
     (erase-buffer)
-    (if json-response 
-	(insert
-	 (cdr (assoc 'translatedText (assoc 'responseData json-response))))
-      (error "Google API has changed ; please look for a new version of babel.el"))))
+    (let ((resp-text (assoc-> json-response '(data translations 0 translatedText)))
+          (err-text (assoc-> json-response '(error message))))
+      (if resp-text
+          (insert resp-text)
+        (if err-text
+            (error "api error: %s" err-text)
+          (error "Google API has changed ; please look for a new version of babel.el"))))))
 
 (defconst babel-apertium-languages
   '(("English" . "en")

--- a/babel.el
+++ b/babel.el
@@ -924,6 +924,11 @@ If optional argument HERE is non-nil, insert version number at point."
 
 (easy-menu-add-item nil '("tools") ["Babel Translation" babel t])
 
+(defun mm-encode-coding-string (str coding-system)
+  (if coding-system
+      (encode-coding-string str coding-system)
+    str))
+
 (provide 'babel)
 
 ;;; babel.el ends here


### PR DESCRIPTION
Example usage:

```lisp
ELISP> (setf babel-google-translate-api-key "fake-WiOtCVQP3rJZ44_kIOOM2Tw-EY5VMCTer0k")
ELISP> (babel-string "The quick brown fox jumps over the lazy dog." "en" "es" 'google)
"El zorro marrón rápido salta sobre el perro perezoso."
ELISP> 
```