### PR TITLE
Fix invalid XEmacs compat function usage

### DIFF
--- a/babel.el
+++ b/babel.el
@@ -404,7 +404,7 @@ function, not available on other emacsen"
       (let* ((url-show-status nil)
 	     (tmp (url-retrieve-synchronously url)))
 	(unless (cadr (url-insert tmp))
-	  (mm-decode-coding-region (point-min) (point-max) 'utf-8))
+	  (decode-coding-region (point-min) (point-max) 'utf-8))
 	(kill-buffer tmp)))))
 
 (defun babel-wash-regex (regex)


### PR DESCRIPTION
mm-decode-coding-region has been removed from Emacs in 2016.

Refs #11